### PR TITLE
Change nav to fixed, reword to get started

### DIFF
--- a/css/common.css
+++ b/css/common.css
@@ -1,5 +1,9 @@
 @import url('https://fonts.googleapis.com/css2?family=Inconsolata&display=swap');
 
+body {
+    padding-top: 75px;
+}
+
 .header-text {
     color: #014380;
     text-align: center;

--- a/en/gettingStarted.html
+++ b/en/gettingStarted.html
@@ -22,72 +22,15 @@
         ></script>
         <script src="../dist/common.js"></script>
         <script src="../dist/gettingStarted.js"></script>
+        <script>
+            $(document).ready(function () {
+                $('#loadNavBar').load('header.html');
+                $('#loadFooter').load('footer.html');
+            });
+        </script>
     </head>
-    <div class="alert alert-warning" role="alert">
-        <span class="text-center"
-            >This website is currently in development. Anything you see is
-            subject to change.
-        </span>
-        <button
-            type="button"
-            class="close"
-            data-dismiss="alert"
-            aria-label="Close"
-        >
-            <span aria-hidden="true">&times;</span>
-        </button>
-    </div>
-    <nav class="navbar navbar-expand-lg navbar-light bg-light">
-        <a class="navbar-brand align-baseline" href="index.html"
-            ><strong>vcpkg</strong></a
-        >
-        <button
-            class="navbar-toggler"
-            type="button"
-            data-toggle="collapse"
-            data-target="#navbarSupportedContent"
-            aria-controls="navbarSupportedContent"
-            aria-expanded="false"
-            aria-label="Toggle navigation"
-        >
-            <span class="navbar-toggler-icon"></span>
-        </button>
 
-        <div class="collapse navbar-collapse" id="navbarSupportedContent">
-            <ul class="navbar-nav mr-auto">
-                <li class="nav-item active">
-                    <a class="nav-link" href="gettingStarted.html"
-                        >Getting Started
-                    </a>
-                </li>
-                <li class="nav-item active">
-                    <a class="nav-link" href="packages.html">Packages</a>
-                </li>
-                <li class="nav-item active">
-                    <a
-                        class="nav-link"
-                        href="https://vcpkg.readthedocs.io/en/latest/"
-                    >
-                        Documentation
-                    </a>
-                </li>
-                <li class="nav-item active">
-                    <a
-                        class="nav-link"
-                        href="https://github.com/microsoft/vcpkg"
-                        >GitHub</a
-                    >
-                </li>
-                <li class="nav-item active">
-                    <a
-                        class="nav-link"
-                        href="https://devblogs.microsoft.com/cppblog/?s=vcpkg"
-                        >Blog</a
-                    >
-                </li>
-            </ul>
-        </div>
-    </nav>
+    <div id="loadNavBar"></div>
 
     <body>
         <div class="header-text">

--- a/en/header.html
+++ b/en/header.html
@@ -1,0 +1,57 @@
+<div class="alert alert-warning" role="alert">
+    <span class="text-center"
+        >This website is currently in development. Anything you see is subject
+        to change.
+    </span>
+    <button type="button" class="close" data-dismiss="alert" aria-label="Close">
+        <span aria-hidden="true">&times;</span>
+    </button>
+</div>
+
+<nav class="navbar navbar-expand-lg navbar-light bg-light fixed-top">
+    <a class="navbar-brand align-baseline" href="index.html"
+        ><strong>vcpkg</strong></a
+    >
+    <button
+        class="navbar-toggler"
+        type="button"
+        data-toggle="collapse"
+        data-target="#navbarSupportedContent"
+        aria-controls="navbarSupportedContent"
+        aria-expanded="false"
+        aria-label="Toggle navigation"
+    >
+        <span class="navbar-toggler-icon"></span>
+    </button>
+
+    <div class="collapse navbar-collapse" id="navbarSupportedContent">
+        <ul class="navbar-nav mr-auto">
+            <li class="nav-item active">
+                <a class="nav-link" href="gettingStarted.html">Get Started </a>
+            </li>
+            <li class="nav-item active">
+                <a class="nav-link" href="packages.html">Packages</a>
+            </li>
+            <li class="nav-item active">
+                <a
+                    class="nav-link"
+                    href="https://vcpkg.readthedocs.io/en/latest/"
+                >
+                    Documentation
+                </a>
+            </li>
+            <li class="nav-item active">
+                <a class="nav-link" href="https://github.com/microsoft/vcpkg"
+                    >GitHub</a
+                >
+            </li>
+            <li class="nav-item active">
+                <a
+                    class="nav-link"
+                    href="https://devblogs.microsoft.com/cppblog/?s=vcpkg"
+                    >Blog</a
+                >
+            </li>
+        </ul>
+    </div>
+</nav>

--- a/en/index.html
+++ b/en/index.html
@@ -23,72 +23,15 @@
         <script src="../dist/index.js"></script>
 
         <script async defer src="https://buttons.github.io/buttons.js"></script>
+        <script>
+            $(document).ready(function () {
+                $('#loadNavBar').load('header.html');
+                $('#loadFooter').load('footer.html');
+            });
+        </script>
     </head>
-    <div class="alert alert-warning" role="alert">
-        <span class="text-center"
-            >This website is currently in development. Anything you see is
-            subject to change.
-        </span>
-        <button
-            type="button"
-            class="close"
-            data-dismiss="alert"
-            aria-label="Close"
-        >
-            <span aria-hidden="true">&times;</span>
-        </button>
-    </div>
-    <nav class="navbar navbar-expand-lg navbar-light bg-light">
-        <a class="navbar-brand align-baseline" href="index.html"
-            ><strong>vcpkg</strong></a
-        >
-        <button
-            class="navbar-toggler"
-            type="button"
-            data-toggle="collapse"
-            data-target="#navbarSupportedContent"
-            aria-controls="navbarSupportedContent"
-            aria-expanded="false"
-            aria-label="Toggle navigation"
-        >
-            <span class="navbar-toggler-icon"></span>
-        </button>
 
-        <div class="collapse navbar-collapse" id="navbarSupportedContent">
-            <ul class="navbar-nav mr-auto">
-                <li class="nav-item active">
-                    <a class="nav-link" href="gettingStarted.html"
-                        >Getting Started
-                    </a>
-                </li>
-                <li class="nav-item active">
-                    <a class="nav-link" href="packages.html">Packages</a>
-                </li>
-                <li class="nav-item active">
-                    <a
-                        class="nav-link"
-                        href="https://vcpkg.readthedocs.io/en/latest/"
-                    >
-                        Documentation
-                    </a>
-                </li>
-                <li class="nav-item active">
-                    <a
-                        class="nav-link"
-                        href="https://github.com/microsoft/vcpkg"
-                        >GitHub</a
-                    >
-                </li>
-                <li class="nav-item active">
-                    <a
-                        class="nav-link"
-                        href="https://devblogs.microsoft.com/cppblog/?s=vcpkg"
-                        >Blog</a
-                    >
-                </li>
-            </ul>
-        </div>
-    </nav>
+    <div id="loadNavBar"></div>
 
     <body>
         <header class="masthead">

--- a/en/packages.html
+++ b/en/packages.html
@@ -25,72 +25,16 @@
         <script src="../dist/common.js"></script>
         <script src="../dist/packages.js"></script>
         <script async defer src="https://buttons.github.io/buttons.js"></script>
+        <script>
+            $(document).ready(function () {
+                $('#loadNavBar').load('header.html');
+                $('#loadFooter').load('footer.html');
+            });
+        </script>
     </head>
-    <div class="alert alert-warning" role="alert">
-        <span class="text-center"
-            >This website is currently in development. Anything you see is
-            subject to change.
-        </span>
-        <button
-            type="button"
-            class="close"
-            data-dismiss="alert"
-            aria-label="Close"
-        >
-            <span aria-hidden="true">&times;</span>
-        </button>
-    </div>
-    <nav class="navbar navbar-expand-lg navbar-light bg-light">
-        <a class="navbar-brand align-baseline" href="index.html"
-            ><strong>vcpkg</strong></a
-        >
-        <button
-            class="navbar-toggler"
-            type="button"
-            data-toggle="collapse"
-            data-target="#navbarSupportedContent"
-            aria-controls="navbarSupportedContent"
-            aria-expanded="false"
-            aria-label="Toggle navigation"
-        >
-            <span class="navbar-toggler-icon"></span>
-        </button>
 
-        <div class="collapse navbar-collapse" id="navbarSupportedContent">
-            <ul class="navbar-nav mr-auto">
-                <li class="nav-item active">
-                    <a class="nav-link" href="gettingStarted.html"
-                        >Getting Started
-                    </a>
-                </li>
-                <li class="nav-item active">
-                    <a class="nav-link" href="packages.html">Packages</a>
-                </li>
-                <li class="nav-item active">
-                    <a
-                        class="nav-link"
-                        href="https://vcpkg.readthedocs.io/en/latest/"
-                    >
-                        Documentation
-                    </a>
-                </li>
-                <li class="nav-item active">
-                    <a
-                        class="nav-link"
-                        href="https://github.com/microsoft/vcpkg"
-                        >GitHub</a
-                    >
-                </li>
-                <li class="nav-item active">
-                    <a
-                        class="nav-link"
-                        href="https://devblogs.microsoft.com/cppblog/?s=vcpkg"
-                        >Blog</a
-                    >
-                </li>
-            </ul>
-        </div>
-    </nav>
+    <div id="loadNavBar"></div>
+
     <body>
         <div class="header-text">
             <h1>Browse Packages</h1>


### PR DESCRIPTION
- Nav bar is now fixed to top when scrolling
- The wording of "Getting Started" is simplified to "Get Started" in the nav bar
- the nav bar + alert have been moved into a single file (header.html) to avoid code duplication