### PR TITLE
Add link validation script

### DIFF
--- a/scripts/validateLinks.js
+++ b/scripts/validateLinks.js
@@ -1,0 +1,111 @@
+'use strict';
+
+const fs = require('fs/promises');
+const { dirname } = require('path');
+const path = require('path');
+const { exit } = require('process');
+
+if (process.argv.length != 2) {
+    console.log("Usage: node validateLinks.js")
+    exit(1);
+}
+const destDir = path.dirname(__dirname);
+
+/**
+ * @param {string[]} docs_set
+ * @param {string} path
+ */
+async function get_pages_recursive(docs_set, path) {
+    var dirents = await fs.readdir(path, { encoding: 'utf-8', withFileTypes: true });
+    var promises = [];
+    for (var ent of dirents) {
+        if (ent.isDirectory()) {
+            promises.push(get_pages_recursive(docs_set, path + "/" + ent.name));
+        } else if (ent.name.endsWith(".html")) {
+            docs_set.push(path + "/" + ent.name);
+        }
+    }
+    for (var promise of promises) {
+        await promise;
+    }
+}
+
+/**
+ * @param {string} page
+ * @returns {{links: [string,string][], fragments: {string}}}
+ */
+async function load_page_info(page, relative_dir) {
+    const ret = { links: [], fragments: {} };
+    const content = await fs.readFile(page, 'utf-8');
+    for (const match of content.matchAll(/ href="([^"?#]+)(#([^"?]*))?([^"]*)?"/g)) {
+        // skip external links
+        if (match[1].startsWith("https://") || match[1].startsWith("http://")) continue;
+        // skip mailto
+        if (match[1].startsWith("mailto:")) continue;
+        // skip encoded links
+        if (match[1].startsWith("&")) continue;
+        // skip non-page links for now
+        if (match[1].startsWith("/css") || match[1].startsWith("/assets")) continue;
+        if (match[1].startsWith("/")) {
+            // Link is already relative to doc root
+            ret.links.push([match[1], match[3]]);
+        } else {
+            var dir = relative_dir;
+            var subpath = match[1];
+            while (subpath.startsWith("../")) {
+                dir = dirname(dir);
+                subpath = subpath.substring(3);
+            }
+            ret.links.push([dir + "/" + subpath, match[3]]);
+        }
+    }
+    for (const match of content.matchAll(/ id="([^"]*)"/g)) {
+        ret.fragments[match[1]] = true;
+    }
+    for (const match of content.matchAll(/ name="([^"]*)"/g)) {
+        ret.fragments[match[1]] = true;
+    }
+    return ret;
+}
+/**
+ * @param {string} page
+ * @param {{[index: string]: {links: [string,string][], fragments: {string}}}} pages_info
+ * @returns {boolean} true if errors were found
+ */
+function validate_page(page, pages_info) {
+    var rc = false;
+    const page_info = pages_info[page];
+    for (const link of page_info.links) {
+        if (!(link[0] in pages_info)) {
+            console.log(`Broken internal link ${page} -> ${link[0]}`);
+            rc = true;
+        } else if (link[1] !== undefined && !(link[1] in pages_info[link[0]].fragments)) {
+            console.log(`Broken fragment link ${page} -> ${link[0]}#${link[1]}`);
+            rc = true;
+        }
+    }
+}
+
+/** @returns {boolean} true if an error occurred */
+async function main() {
+    var pages = [];
+    await get_pages_recursive(pages, destDir + "/en");
+
+    var pages_info = {};
+    for (var page of pages) {
+        var relative = page.substring(destDir.length);
+        pages_info[relative] = load_page_info(page, dirname(relative));
+    }
+
+    for (var page in pages_info) {
+        pages_info[page] = await pages_info[page];
+    }
+
+    var rc = false;
+    for (var page in pages_info) {
+        rc ||= validate_page(page, pages_info);
+    }
+    return rc;
+}
+
+return main() ? 1 : 0;


### PR DESCRIPTION
This PR adds a script to check all documentation-internal links, ensuring that pages and anchors exist. Unfortunately, it operates on the generated html files, so it isn't easy to add as a pipeline step in microsoft/vcpkg for docs PRs.

It already has found several existing issues (which prevent me from adding it as a mandatory pipeline step):
```
$ node scripts/validateLinks.js
Broken internal link /en/docs/README.html -> /en/docs/specifications/export-command.html
Broken internal link /en/docs/README.html -> /en/docs/specifications/feature-packages.html
Broken fragment link /en/docs/about/faq.html -> /en/docs/users/integration.html#export
Broken fragment link /en/docs/users/config-environment.html -> /en/docs/users/binarycaching.html#Configuration
Broken fragment link /en/docs/users/config-environment.html -> /en/docs/users/binarycaching.html#Configuration
Broken fragment link /en/docs/users/config-environment.html -> /en/docs/users/binarycaching.html#Configuration
Broken fragment link /en/docs/users/config-environment.html -> /en/docs/users/binarycaching.html#NuGets-cache
Broken internal link /en/docs/users/integration.html -> /en/README.html
Broken fragment link /en/docs/users/integration.html -> /en/docs/users/triplets.html#VCPKG_CHAINLOAD_TOOLCHAIN_FILE
Broken fragment link /en/docs/users/manifests.html -> /en/docs/users/integration.html#cmake
Broken fragment link /en/docs/users/manifests.html -> /en/docs/users/integration.html#with-msbuild
Broken fragment link /en/docs/users/triplets.html -> /en/docs/users/integration.html#triplet-selection
Broken internal link /en/docs/maintainers/portfile-functions.html -> /en/docs/maintainers/ports/vcpkg-gn/vcpkg_gn_configure.html
Broken internal link /en/docs/maintainers/portfile-functions.html -> /en/docs/maintainers/ports/vcpkg-gn/vcpkg_gn_install.html
Broken fragment link /en/docs/maintainers/pr-review-checklist.html -> /en/docs/maintainers/maintainer-guide.html#Avoid-deprecated-helper-functions
Broken fragment link /en/docs/maintainers/pr-review-checklist.html -> /en/docs/maintainers/maintainer-guide.html#Avoid-excessive-comments-in-portfiles
Broken internal link /en/docs/maintainers/vcpkg_configure_gn.html -> /en/docs/maintainers/ports/vcpkg-gn/vcpkg_gn_configure.html
Broken internal link /en/docs/maintainers/vcpkg_install_gn.html -> /en/docs/maintainers/ports/vcpkg-gn/vcpkg_gn_install.html
```

I intend to address these issues in the main vcpkg repository, then regenerate the website and add this as a mandatory validation step to prevent future regressions.