### PR TITLE
Add index redirects for docs

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,5 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Redirecting to README.html</title>
+<meta http-equiv="refresh" content="0; URL=https://vcpkg.io/en/docs/README.html">
+<link rel="canonical" href="https://vcpkg.io/en/docs/README.html">

--- a/en/docs/index.html
+++ b/en/docs/index.html
@@ -1,0 +1,5 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Redirecting to README.html</title>
+<meta http-equiv="refresh" content="0; URL=https://vcpkg.io/en/docs/README.html">
+<link rel="canonical" href="https://vcpkg.io/en/docs/README.html">

--- a/scripts/generatePages.js
+++ b/scripts/generatePages.js
@@ -27,10 +27,13 @@ async function main() {
     }
 
     // Redirect from https://vcpkg.io/en/docs/ to https://vcpkg.io/en/docs/README.md
-    await fs.copyFile(templatesDir + "/readme-redirect.html", enDir + "/docs/index.html");
+    const enDocsDir = enDir + "/docs";
+    try { await fs.mkdir(enDocsDir); } catch (e) {}
+    await fs.copyFile(templatesDir + "/readme-redirect.html", enDocsDir + "/index.html");
     // Redirect from https://vcpkg.io/docs/ to https://vcpkg.io/en/docs/README.md
-    await fs.mkdir(rootDir + "/docs");
-    await fs.copyFile(templatesDir + "/readme-redirect.html", rootDir + "/docs/index.html");
+    const docsDir = rootDir + "/docs";
+    try { await fs.mkdir(docsDir); } catch (e) {}
+    await fs.copyFile(templatesDir + "/readme-redirect.html", docsDir + "/index.html");
 }
 
 main();

--- a/scripts/generatePages.js
+++ b/scripts/generatePages.js
@@ -25,6 +25,12 @@ async function main() {
         await render(templatesDir + "/" + t, enDir + "/" + t, view);
         console.log("Generated " + enDir + "/" + t);
     }
+
+    // Redirect from https://vcpkg.io/en/docs/ to https://vcpkg.io/en/docs/README.md
+    await fs.copyFile(templatesDir + "/readme-redirect.html", enDir + "/docs/index.html");
+    // Redirect from https://vcpkg.io/docs/ to https://vcpkg.io/en/docs/README.md
+    await fs.mkdir(rootDir + "/docs");
+    await fs.copyFile(templatesDir + "/readme-redirect.html", rootDir + "/docs/index.html");
 }
 
 main();

--- a/scripts/rebuild.sh
+++ b/scripts/rebuild.sh
@@ -11,7 +11,7 @@ then
     git -C ../vcpkg checkout FETCH_HEAD
 fi
 npm ci
-rm -rf ../en
+rm -rf ../en ../docs
 node generatePages.js
 node generateDocs.js ../vcpkg/docs
 node validateLinks.js

--- a/templates/readme-redirect.html
+++ b/templates/readme-redirect.html
@@ -1,0 +1,5 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Redirecting to README.html</title>
+<meta http-equiv="refresh" content="0; URL=https://vcpkg.io/en/docs/README.html">
+<link rel="canonical" href="https://vcpkg.io/en/docs/README.html">


### PR DESCRIPTION
This PR adds automatic redirects from `https://vcpkg.io/en/docs/` and `https://vcpkg.io/docs/` to `https://vcpkg.io/en/docs/README.md`.