### PR TITLE
Hotfix for packages with array descriptions

### DIFF
--- a/dist/packages.js
+++ b/dist/packages.js
@@ -241,6 +241,9 @@ function renderPackageDetails(package, packageDiv, isCard) {
     // Package Description (HTML version)
     var fullDesc = package.Description;
     if (fullDesc) {
+        if (Array.isArray(fullDesc)) {
+            fullDesc = fullDesc.join("\n");
+        }
         var descriptionDiv = isCard
             ? renderCardDescription(fullDesc)
             : renderModalDescription(fullDesc);


### PR DESCRIPTION
The packages.json generator was rewritten, which now passes through the full description array for packages. This broke the card renderer, which expected a string.

As an immediate workaround, I've added a quick fixup that handles an array in the `.description` -- longer term, the generator should be fixed.