### PR TITLE
fix syntax error

### DIFF
--- a/.github/workflows/sync-package-periodically.yml
+++ b/.github/workflows/sync-package-periodically.yml
@@ -69,6 +69,6 @@ jobs:
                 title: title,
                 body: "This PR was automatically created by a GitHub Action triggered by a schedule. It updates the package metadata and website content.",
                 head: newBranch,
-                base: "main" 
+                base: "main"
               };
             await github.rest.pulls.create(output);

--- a/.github/workflows/sync-package-periodically.yml
+++ b/.github/workflows/sync-package-periodically.yml
@@ -68,7 +68,7 @@ jobs:
                 repo: repo,
                 title: title,
                 body: "This PR was automatically created by a GitHub Action triggered by a schedule. It updates the package metadata and website content.",
-                head: ${newBranch},
-                base: "main"
+                head: newBranch,
+                base: "main" 
               };
             await github.rest.pulls.create(output);


### PR DESCRIPTION
In JavaScript, when you're inside an object literal, you don't need to use `${}` to reference variables. This syntax is only needed inside template strings (strings enclosed in backticks ```). 