### PR TITLE
add manage cookie at site footer

### DIFF
--- a/css/common.css
+++ b/css/common.css
@@ -527,6 +527,16 @@ footer p {
   margin-right: 0%;
 }
 
+.footer-info-group-mc {
+  margin-left: 15%;
+  position: relative;
+  z-index: 1;
+  min-width: 50px;
+  max-width: 250px;
+  margin-right: 0%;
+  white-space: normal;
+}
+
 .footer-info-group-privacy {
   margin-left: 15%;
   position: relative;

--- a/en/index.html
+++ b/en/index.html
@@ -339,6 +339,11 @@
           <a class="footer-link" href="/en/docs/about/privacy.html">Privacy</a>
         </div>
       </div>
+      <div class="footer-info-group-mc">
+        <div class="footer-description">
+          <a style="display: none;" class="manageCookieChoice footer-link" href="#" onclick="javascript:manageConsent(); return false;">Manage cookies</a>
+        </div>
+      </div>
       <div class="footer-info-group-privacy">
         <div class="footer-description">
           <a style="display: none;" class="managePrivacyChoice footer-link"

--- a/en/packages.html
+++ b/en/packages.html
@@ -284,6 +284,11 @@
           <a class="footer-link" href="/en/docs/about/privacy.html">Privacy</a>
         </div>
       </div>
+      <div class="footer-info-group-mc">
+        <div class="footer-description">
+          <a style="display: none;" class="manageCookieChoice footer-link" href="#" onclick="javascript:manageConsent(); return false;">Manage cookies</a>
+        </div>
+      </div>
       <div class="footer-info-group-privacy">
         <div class="footer-description">
           <a style="display: none;" class="managePrivacyChoice footer-link"

--- a/scripts/consentAndAnalytics.js
+++ b/scripts/consentAndAnalytics.js
@@ -41,7 +41,40 @@ window.addEventListener('DOMContentLoaded', function () {
             siteConsent = _siteConsent; //siteConsent is used to get the current consent
         }
     });
+
+    siteConsent.onConsentChanged(watchConsentChanges);
+
+    if (siteConsent.isConsentRequired) {
+        document.getElementsByClassName('manageCookieChoice')[0].style.display = 'inline-block';
+    }
+    else {
+        //$(".manageCookieChoice").css("display", "none");
+        document.getElementsByClassName('manageCookieChoice')[0].style.display = 'none';
+    }
+
+    if (!siteConsent.getConsentFor(WcpConsent.consentCategories.Analytics)) {
+        dropAnalyticsCookies();
+    }
+
+    function watchConsentChanges(consents) {
+        //scan through the categories and take action based on user consent.
+        if (!siteConsent.getConsentFor(WcpConsent.consentCategories.Analytics)) {
+            dropAnalyticsCookies();
+        }
+    }
 });
+
+function dropAnalyticsCookies() {
+    clearCookie('_ga', document.domain, '/');
+    clearCookie('_gid', document.domain, '/');
+    clearCookie('_gat', document.domain, '/');
+}
+
+function manageConsent() {
+    if (siteConsent.isConsentRequired) {
+        siteConsent.manageConsent();
+    }
+}
 
 //Detect GPC
 const globalPrivacyControlEnabled = navigator.globalPrivacyControl;

--- a/templates/footer.html
+++ b/templates/footer.html
@@ -56,6 +56,11 @@
           <a class="footer-link" href="/en/docs/about/privacy.html">Privacy</a>
         </div>
       </div>
+      <div class="footer-info-group-mc">
+        <div class="footer-description">
+          <a style="display: none;" class="manageCookieChoice footer-link" href="#" onclick="javascript:manageConsent(); return false;">Manage cookies</a>
+        </div>
+      </div>
       <div class="footer-info-group-privacy">
         <div class="footer-description">
           <a style="display: none;" class="managePrivacyChoice footer-link"


### PR DESCRIPTION
We are correctly popping the cookie consent banner for EU visitors, but we also need to show a "Manage cookies" link in the site footer. We are doing this correctly for the iis.net website and other websites, but it is missing for vcpkg.io. 

Clicking "Manage cookies: in the footer should bring the user to the same place that "Manage cookies" brings them in the consent banner.