### PR TITLE
Disable text selection in tab headers

### DIFF
--- a/css/package.css
+++ b/css/package.css
@@ -101,6 +101,7 @@ ul.tab-container {
     padding-block: 5px;
     padding-inline: 15px;
     border-radius: 5px 5px 0 0;
+    user-select: none;
 }
 
 .tab:hover{


### PR DESCRIPTION
This disables the ability for the user to select the text of tab headers. Without this, the cursor changes into a text selection cursor when hovering over tabs which is unexpected.