### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -9,10 +9,7 @@ permissions:
 jobs:
   validate:
     runs-on: ubuntu-latest
-    
-    env:
-     Codeql.Enabled: true
-     
+
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -3,6 +3,9 @@ name: Site Validation
 on:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   validate:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/vcpkg/vcpkg.github.io/security/code-scanning/1](https://github.com/vcpkg/vcpkg.github.io/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root level of the workflow file. This block will explicitly set the permissions to the minimum required for the workflow to function. Based on the workflow's steps, it only needs to read the repository contents to validate the website and check for differences. Therefore, we will set `contents: read` as the permission.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
